### PR TITLE
Add trim support

### DIFF
--- a/profiles/default
+++ b/profiles/default
@@ -77,5 +77,5 @@ export SERVICES="\
 	NetworkManager \
 	lightdm \
 	bluetooth \
-	fs-trim.timer \
+	fstrim.timer \
 "

--- a/profiles/default
+++ b/profiles/default
@@ -77,4 +77,5 @@ export SERVICES="\
 	NetworkManager \
 	lightdm \
 	bluetooth \
+	fs-trim.timer \
 "


### PR DESCRIPTION
This unit for periodical trim is installed with the base group, so it only has to be activated. You can read up on it here: https://wiki.archlinux.org/index.php/Solid_state_drive#Periodic_TRIM