### PR TITLE
Added fonts Steam uses

### DIFF
--- a/profiles/default
+++ b/profiles/default
@@ -63,6 +63,8 @@ export PACKAGES="\
 	lib32-opencl-nvidia \
 	nvidia-utils \
 	lib32-nvidia-utils \
+	ttf-liberation \
+	wqy-zenhei \
 "
 
 export AUR_PACKAGES="\


### PR DESCRIPTION
The liberation fonts will be used by Steam if they are installed. SteamOS uses these fonts as well.
The wqy-zenhei package allows Steam to display asian language characters.