### PR TITLE
Update lsb_release output based on the channel and version used for build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -113,6 +113,13 @@ polkit.addRule(function(action, subject) {
 
 echo "${SYSTEM_NAME}" > /etc/hostname
 
+echo "
+LSB_VERSION=1.4
+DISTRIB_ID=${CHANNEL}
+DISTRIB_RELEASE=${VERSION}
+DISTRIB_DESCRIPTION=${CHANNEL}
+" > /etc/lsb-release
+
 # steam controller fix, xbox one s bluetooth fix, amdgpu setup
 echo "
 blacklist hid_steam


### PR DESCRIPTION
This is probably the easiest way to get this working. Now the channel and the version specified when running build.sh are used for the release which Steam displays. Replacing DISTRIB_DESCRIPTION with a better looking version of the name might be nice as well, but I'll leave that up to you.