### PR TITLE
Removed some packages which aren't used

### DIFF
--- a/profiles/default
+++ b/profiles/default
@@ -3,7 +3,6 @@
 export SIZE="10GB"
 
 export PACKAGES="\
-	htop \
 	lightdm \
 	accountsservice \
 	xorg-server \
@@ -18,8 +17,6 @@ export PACKAGES="\
 	pulseaudio-alsa \
 	pulseaudio-bluetooth \
 	sudo \
-	python \
-	flatpak \
 	vulkan-icd-loader \
 	lib32-vulkan-icd-loader \
 	libva-mesa-driver \


### PR DESCRIPTION
Using htop and flatpak is currently not doable from within Steam. Python should be a dependency.