### PR TITLE
Added mdns support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -128,6 +128,9 @@ options amdgpu cik_support=1
 options bluetooth disable_ertm=1
 " > /etc/modprobe.d/${SYSTEM_NAME}.conf
 
+# enable multicast dns in avahi
+sed -i "/^hosts:/ s/resolve/mdns resolve/" /etc/nsswitch.conf
+
 # yet another steam controller fix
 echo "uinput" > /etc/modules-load.d/${SYSTEM_NAME}.conf
 

--- a/profiles/default
+++ b/profiles/default
@@ -70,6 +70,7 @@ export PACKAGES="\
 	libretro-snes9x \
 	libretro-yabause \
 	dolphin-emu \
+	nss-mdns \
 "
 
 export AUR_PACKAGES="\
@@ -90,4 +91,5 @@ export SERVICES="\
 	lightdm \
 	bluetooth \
 	fstrim.timer \
+	avahi-daemon \
 "


### PR DESCRIPTION
This makes users able to connect to servers on their GamerOS machine with as gameros.local instead of the full IP address. This should work with any system with multicast DNS support. In my test it worked with Debian 10. I am not able to test with Windows 10 or MacOS here, but it should work with those. It did not work for me with Android or Windows 7.