### PR TITLE
Added haveged for faster boot on low entropy systems

### DIFF
--- a/profiles/default
+++ b/profiles/default
@@ -70,6 +70,7 @@ export PACKAGES="\
 	libretro-yabause \
 	dolphin-emu \
 	nss-mdns \
+	haveged \
 "
 
 export AUR_PACKAGES="\
@@ -94,4 +95,5 @@ export SERVICES="\
 	fstrim.timer \
 	avahi-daemon \
 	steam-buddy \
+	haveged \
 "


### PR DESCRIPTION
I was having issues with GamerOS booting slow on my Steam Machine.
Installing and enabling haveged, an entropy generator, sped up my boot
times by 2 minutes.