### PR TITLE
Support changing lights on Alienware Alpha

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -91,7 +91,7 @@ passwd --lock root
 groupadd -r autologin
 useradd -m ${USERNAME} -G autologin,wheel
 echo "${USERNAME}:${USERNAME}" | chpasswd
-echo "${USERNAME}   ALL=(ALL) ALL" >> /etc/sudoers
+sed -i "\$i%${USERNAME}   ALL=(ALL) ALL" /etc/sudoers
 
 echo "
 [LightDM]

--- a/profiles/default
+++ b/profiles/default
@@ -84,6 +84,7 @@ export AUR_PACKAGES="\
 	libretro-flycast-git \
 	steam-buddy \
 	retroarch-autoconfig-udev-git \
+	alienware-alpha-wmi \
 "
 
 export SERVICES="\


### PR DESCRIPTION
This makes you able to select Alien FX in the menu if you have an Alienware Alpha or Steam Machine to change the color of the lights on the system.

I've created a package on the AUR which takes the script from the steamos-base-files. This is what is used here.

I did find a bug while working on this. The files in ``/etc/sudoers.d`` aren't loaded by sudo because ``build.sh`` adds a line below the include line in the sudoers file. With this pull request this is fixed by writing to the second to last line instead.