### PR TITLE
Added Xbox One Wireless adapter support

### DIFF
--- a/profiles/default
+++ b/profiles/default
@@ -88,6 +88,7 @@ export AUR_PACKAGES="\
 	steam-buddy \
 	retroarch-autoconfig-udev-git \
 	alienware-alpha-wmi \
+	xow-git \
 "
 
 export SERVICES="\
@@ -102,4 +103,5 @@ export SERVICES="\
 	steam-buddy-proxy@gamer.service \
 	steam-buddy-proxy@gamer.socket \
 	haveged \
+	xow \
 "


### PR DESCRIPTION
This change adds support for the Xbox One Wireless adapter by [medusalix](https://github.com/medusalix/xow).

It's tested on my box. The only problem is, after a restart you have to pair your controllers again. I'm not sure how to fix this, but the the xow project is very active at the moment, so maybe it's an upstream fix.

P.S. For me the re-pair problem only occurs, when the controllers are already connected during a reboot.