### PR TITLE
Add policykit action and rule to allow SteamVR to setcap on vrcompositor

### DIFF
--- a/rootfs/etc/polkit-1/rules.d/41-steamvr.rules
+++ b/rootfs/etc/polkit-1/rules.d/41-steamvr.rules
@@ -1,0 +1,10 @@
+/* Allow members of the wheel group to execute the defined actions 
+ * without password authentication, similar to "sudo NOPASSWD:"
+ */
+polkit.addRule(function(action, subject) {
+    if ((action.id == "org.gameros.steamvr.pkexec") &&
+        subject.isInGroup("wheel"))
+    {
+        return polkit.Result.YES;
+    }
+});

--- a/rootfs/usr/share/polkit-1/actions/org.gameros.steamvr.policy
+++ b/rootfs/usr/share/polkit-1/actions/org.gameros.steamvr.policy
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?> <!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd"> 
+<policyconfig>
+  <action id="org.gameros.steamvr.pkexec">
+    <message>Authentication is required to change steamvr compositor capabilities</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/setcap</annotate>
+    <annotate key="org.freedesktop.policykit.exec.argv1">CAP_SYS_NICE=eip</annotate>
+    <annotate key="org.freedesktop.policykit.exec.argv2">/home/gamer/.local/share/Steam/steamapps/common/SteamVR/bin/linux64/vrcompositor-launcher</annotate>
+  </action>
+</policyconfig>


### PR DESCRIPTION
When launching SteamVR, you will be prompted for sudo rights to run `setcaps` on `vrcompositor-launcher`, but GamerOS does not have a policykit agent running to display a password prompt:

```
    if ! ${STEAM_ZENITY} --no-wrap --question --text="SteamVR requires superuser access to finish setup. Proceed?"; then
        pErr 'Error: user declined superuser request.'
        return 1
    fi

    pkexec setcap CAP_SYS_NICE=eip $STEAMVR_TOOLSDIR/bin/linux64/vrcompositor-launcher
```

This PR adds a policykit action and rule to allow sudoless access for `vrstartup.sh` to set this capability. 