### PR TITLE
Add vkbasalt package from AUR

### DIFF
--- a/profiles/default
+++ b/profiles/default
@@ -91,6 +91,7 @@ export AUR_PACKAGES="\
 	lib32-gamemode \
 	mangohud \
 	lib32-mangohud \
+	vkbasalt \
 "
 
 export SERVICES="\


### PR DESCRIPTION
This PR adds the vkbasalt package from AUR. vkBasalt is a Vulkan post processing layer to enhance the visual graphics of games, which can be optionally enabled per game. More information about it is here:

https://github.com/DadSchoorse/vkBasalt