### PR TITLE
Add steam-native-runtime meta package

### DIFF
--- a/profiles/default
+++ b/profiles/default
@@ -72,6 +72,7 @@ export PACKAGES="\
 	haveged \
 	openbox \
 	termite \
+	steam-native-runtime \
 "
 
 export AUR_PACKAGES="\


### PR DESCRIPTION
This PR adds the `steam-native-runtime` meta package. Without it, I have seen some `libvpau.so.1` errors in SteamVR.