### PR TITLE
Add docker support for building GamerOS images

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -21,6 +21,16 @@ To build the image, run the following command:
 ```
 Replace `<channel>` and `<version>` with your own values. Channel should be a name and version, the version number. Neither the name nor the version should include a hyphen (`-`) character.
 
+## Building the GamerOS image using Docker
+
+To build the docker image, run the following:
+
+`docker build -t gameros-builder:latest .`
+
+Then build the GamerOS image with the following:
+
+`docker run -it --rm -v $(pwd)/output:/output --privileged gameros-builder:latest <channel> <version>`
+
 # Preparing for installation of the image
 
 To be able to install the generated image file (`<channel>-<version>.img.tar.xz`) it will need to be uploaded to a location which is accessible to the GamerOS system on which it will be installed. This can be a webserver or on the GamerOS system itself. In addition, a manifest file needs to be created.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM archlinux:latest
+LABEL contributor="shadowapex@gmail.com"
+
+RUN echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist\n" >> /etc/pacman.conf && \
+	pacman --noconfirm -Syy && \
+	pacman --noconfirm -Syu && \
+	pacman --noconfirm -S arch-install-scripts btrfs-progs pyalpm sudo && \
+	pacman --noconfirm -S --needed base-devel git && \
+	echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+	useradd build -G wheel -m && \
+	su - build -c "git clone https://aur.archlinux.org/pikaur.git /tmp/pikaur" && \
+	su - build -c "cd /tmp/pikaur && makepkg -f" && \
+	pacman --noconfirm -U /tmp/pikaur/pikaur-*.pkg.tar.xz
+
+# Add a fake systemd-run script to workaround pikaur requirement.
+RUN echo -e "#!/bin/bash\nif [[ \"$1\" == \"--version\" ]]; then echo 'fake 244 version'; fi\nmkdir -p /var/cache/pikaur\n" >> /usr/bin/systemd-run && \
+	chmod +x /usr/bin/systemd-run
+
+# Add the project to the container.
+ADD . /gamer-os
+
+# Build pikaur packages as the 'build' user
+ENV BUILD_USER build
+
+# Built image will be moved here. This should be a host mount to get the output.
+ENV OUTPUT_DIR /output
+
+WORKDIR /gamer-os
+ENTRYPOINT ["/gamer-os/build.sh"]


### PR DESCRIPTION
This PR adds support for building GamerOS images in Docker, which addresses some points in #63. 

To get this to work, I needed to make a few modifications to `build.sh` to support running `pikaur` as a normal user. By default, `pikaur` will run as it did before, so these changes shouldn't have any effect building outside Docker.

Also added are optional image output directory environment variables which the Docker image uses to move the image file outside the container.