### PR TITLE
Add ppsspp for PSP support

### DIFF
--- a/manifest
+++ b/manifest
@@ -117,6 +117,7 @@ export AUR_PACKAGES="\
 	alienware-alpha-wmi \
 	bcache-tools \
 	mame-tools \
+	libretro-ppsspp-gameros \
 "
 
 export SERVICES="\

--- a/manifest
+++ b/manifest
@@ -5,7 +5,7 @@ export SYSTEM_DESC="GamerOS"
 export SYSTEM_NAME="gameros"
 export USERNAME="gamer"
 export SIZE="6500MB"
-export ARCHIVE_DATE="2020/09/19"
+export ARCHIVE_DATE="2020/10/24"
 
 export PACKAGES="\
 	htop \
@@ -91,9 +91,9 @@ export PACKAGES="\
 	nano \
 	boost-libs \
 	nvidia-settings \
+	gamemode \
+	lib32-gamemode \
 	chaotic-aur/gamescope-git \
-	chaotic-aur/gamemode \
-	chaotic-aur/lib32-gamemode \
 	chaotic-aur/mangohud \
 	chaotic-aur/lib32-mangohud \
 	chaotic-aur/python-vdf \

--- a/manifest
+++ b/manifest
@@ -110,13 +110,13 @@ export AUR_PACKAGES="\
 	pycrc \
 	python-inotify-simple \
 	steam-tweaks \
+	libretro-ppsspp-gameros \
 	steam-buddy \
 	xow \
 	retroarch-autoconfig-udev-git \
 	alienware-alpha-wmi \
 	bcache-tools \
 	mame-tools \
-	libretro-ppsspp-gameros \
 "
 
 export SERVICES="\

--- a/manifest
+++ b/manifest
@@ -71,7 +71,6 @@ export PACKAGES="\
 	libretro-mupen64plus-next \
 	libretro-nestopia \
 	libretro-parallel-n64 \
-	libretro-ppsspp \
 	libretro-scummvm \
 	libretro-snes9x \
 	libretro-yabause \


### PR DESCRIPTION
This adds a patched version of the libretro-ppsspp package found in the Arch repo. The difference is that this package includes the assets and has been patched to use them. It is required for https://github.com/gamer-os/steam-buddy/pull/101