### PR TITLE
Tweak Retroarch audio latency setting

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -172,6 +172,9 @@ DISTRIB_DESCRIPTION=${SYSTEM_DESC}
 # disable retroarch menu in joypad configs
 find /usr/share/libretro/autoconfig -type f -name '*.cfg' | xargs -d '\n' sed -i '/input_menu_toggle_btn/d'
 
+# set retroarch audio latency to avoid pops and clicks
+sed -i 's/audio_latency = ".*"/audio_latency = "90"/g' /home/gamer/.config/retroarch/retroarch.cfg
+
 # preserve installed package database
 mkdir -p /usr/var/lib/pacman
 cp -r /var/lib/pacman/local /usr/var/lib/pacman/


### PR DESCRIPTION
I experienced some pops and clicks in Super Mario 64 game that went away with this setting (previously set at 64ms). This shouldn't create side effects at all.