### PR TITLE
Better handling of Bluetooth dongles 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -182,7 +182,7 @@ DISTRIB_DESCRIPTION=${SYSTEM_DESC}
 find /usr/share/libretro/autoconfig -type f -name '*.cfg' | xargs -d '\n' sed -i '/input_menu_toggle_btn/d'
 
 # automatically power-on Bluetooth dongles when plugged in
-grep -E ^AutoEnable=.* /etc/bluetooth/main.conf && sed s/^AutoEnable=.*/AutoEnable=true/g /etc/bluetooth/main.conf || echo "AutoEnable=true" >> /etc/bluetooth/main.conf
+grep -E ^AutoEnable=.* /etc/bluetooth/main.conf && sed -i s/^AutoEnable=.*/AutoEnable=true/g /etc/bluetooth/main.conf || echo "AutoEnable=true" >> /etc/bluetooth/main.conf
 
 # preserve installed package database
 mkdir -p /usr/var/lib/pacman

--- a/build.sh
+++ b/build.sh
@@ -181,6 +181,9 @@ DISTRIB_DESCRIPTION=${SYSTEM_DESC}
 # disable retroarch menu in joypad configs
 find /usr/share/libretro/autoconfig -type f -name '*.cfg' | xargs -d '\n' sed -i '/input_menu_toggle_btn/d'
 
+# automatically power-on Bluetooth dongles when plugged in
+grep -E ^AutoEnable=.* /etc/bluetooth/main.conf && sed s/^AutoEnable=.*/AutoEnable=true/g /etc/bluetooth/main.conf || echo "AutoEnable=true" >> /etc/bluetooth/main.conf
+
 # preserve installed package database
 mkdir -p /usr/var/lib/pacman
 cp -r /var/lib/pacman/local /usr/var/lib/pacman/

--- a/manifest
+++ b/manifest
@@ -15,6 +15,7 @@ export PACKAGES="\
 	bluez \
 	bluez-utils \
 	bluez-plugins \
+	bluez-hid2hci \
 	lib32-freetype2 \
 	lib32-curl \
 	lib32-libgpg-error \


### PR DESCRIPTION
I was trying to make the following dongle work with GamerOS : 
![image](https://user-images.githubusercontent.com/10470407/103140866-31671f00-46ec-11eb-900e-84ef1062113c.png)

And to succeed I had to do two operations : 

1. Force HCI mode to make the dongle an actual Bluetooth dongle, because it goes into HID mode by default. This can be achieved in two ways : 
- By pressing the "Connect" button while plugging it in
- By installing the `bluez-hid2hci` package from the [Arch repos](https://archlinux.org/packages/extra/x86_64/bluez-hid2hci/), in order to [automatically force it](https://wiki.archlinux.org/index.php/Bluetooth#Logitech_Bluetooth_USB_Dongle).

The second option is obviously way more convenient, so this pull request adds the package to the `manifest` file in a first commit.

2. Force the Bluetooth controller to automatically be powered on when plugged in : 
If the dongle is plugged in before boot, everything works fine. But if it is plugged after boot, it's necessary to connect through SSH and launch `$ bluetoothctl power on` before any connection can take place.

This pull requests prevents the need to do this by activating an option in a config file as described in the [Arch Wiki](https://wiki.archlinux.org/index.php/Bluetooth#Auto_power-on_after_boot) in a second commit.