### PR TITLE
Use the correct docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM archlinux:base-devel-20210131.0.14634
+FROM archlinux:base-devel-20210214.0.15477
 LABEL contributor="shadowapex@gmail.com"
 
 ENV GLIBC glibc-linux4-2.33-4-x86_64.pkg.tar.zst


### PR DESCRIPTION
I got it to build on Debian 10 like this. I totally forgot you need to use this version specificly.