### PR TITLE
Add `pipewire` and `lib32-pipewire`

### DIFF
--- a/manifest
+++ b/manifest
@@ -20,6 +20,8 @@ export PACKAGES="\
 	lib32-curl \
 	lib32-libgpg-error \
 	networkmanager \
+	pipewire \
+	lib32-pipewire \
 	pulseaudio \
 	lib32-libpulse \
 	pulseaudio-alsa \


### PR DESCRIPTION
Steam beta now needs pipewire or won't start. If a user opts-in into Steam beta client, maybe they can't start the session.