### PR TITLE
Avoid journald chewing up 4G of disk space

### DIFF
--- a/rootfs/etc/systemd/journald.conf.d/00-journal-size.conf
+++ b/rootfs/etc/systemd/journald.conf.d/00-journal-size.conf
@@ -1,0 +1,2 @@
+[Journal]
+SystemMaxUse=50M


### PR DESCRIPTION
On most computers with the current installation, logs made by [`journald` will chew up 4Gib](https://wiki.archlinux.org/title/Systemd/Journal#Journal_size_limit) that can be used for more interesting stuff. 